### PR TITLE
UI improvements and fixes

### DIFF
--- a/front/src/lib/utils/competition.ts
+++ b/front/src/lib/utils/competition.ts
@@ -1,0 +1,10 @@
+import { checkIsNullOrUndefined } from "./validation";
+
+export function getCompetitionUrl(competitionId: string | null) {
+    if (checkIsNullOrUndefined(competitionId)) {
+        console.error('Não foi possível carregar URL da competição. ID da competição inválido.')
+        return null
+    }
+
+    return `https://www.worldcubeassociation.org/competitions/${competitionId}`
+}

--- a/front/src/views/components/common/Footer/Footer.svelte
+++ b/front/src/views/components/common/Footer/Footer.svelte
@@ -2,11 +2,17 @@
 	import GridItem from '../Grid/Item/GridItem.svelte';
 	import Typography from '../Typography/Typography.svelte';
 	import './style.css';
+
+	const emailContact = 'wca@leinadium.dev'
 </script>
 
 <footer>
 	<GridItem direction={'COLUMN'} justifyContent={'center'} alignItems={'center'} gap={1} margin={4}>
-		<Typography type={'caption'} color={'NEUTRAL_DARK_1'}>
+		<Typography
+			type={'caption'}
+			color={'NEUTRAL_DARK_1'}
+			align={'center'}
+		>
 			<a target="_blank" href="https://github.com/Leinadium/ranking-wca">
 				<img class="footer__icon" src="/icons/github-mark.svg" alt="Github" />
 			</a>
@@ -15,6 +21,8 @@
 			e
 			<a target="_blank" href="https://www.jeannelima.com.br/">Jeanne Lima</a>
 			| 2025
+			<br/>
+			Contato: <a target="_blank" href={`mailto:${emailContact}`}>{emailContact}</a> 
 		</Typography>
 	</GridItem>
 </footer>

--- a/front/src/views/components/common/Header/GlobalHeader.svelte
+++ b/front/src/views/components/common/Header/GlobalHeader.svelte
@@ -156,6 +156,10 @@
 		goto(`${baseUrl}/person/${userWcaId}`)
 	}
 
+	function checkIsPersonPage(): boolean {
+		return page?.url?.pathname?.includes('/person/') || false
+	}
+
 	$effect(() => {
 		if (!$authStore.user) return;
 
@@ -234,7 +238,7 @@
 						</InputGroupRoot>
 					</Modal>
 				{:else}
-					{#if !$responsivenessStore.isSmallDevice}
+					{#if checkIsPersonPage() && !$responsivenessStore.isSmallDevice}
 						<GridItem gap={3}>
 							<Typography type={'caption'} color={'NEUTRAL_DARK_1'} align={'right'}>
 								Esse é seu perfil e deseja alterar seu estado?<br />Entre com sua conta WCA

--- a/front/src/views/components/common/VerifiedAccountFlag/VerifiedAccountFlag.svelte
+++ b/front/src/views/components/common/VerifiedAccountFlag/VerifiedAccountFlag.svelte
@@ -6,9 +6,11 @@
 	let { isVerified }: VerifiedAccountFlagProps = $props();
 </script>
 
-<Tooltip text={isVerified ? 'Conta verificada' : 'Verificação de conta pendente'}>
-	<SvgIcon
-		name={isVerified ? 'faCircleCheck' : 'faCircleExclamation'}
-		color={isVerified ? 'PRIMARY_LIGHT_1' : 'ACCENT_WARNING_BASE'}
-	/>
-</Tooltip>
+{#key isVerified}
+	<Tooltip text={isVerified ? 'Conta verificada' : 'Verificação de conta pendente'}>
+		<SvgIcon
+			name={isVerified ? 'faCircleCheck' : 'faCircleExclamation'}
+			color={isVerified ? 'PRIMARY_LIGHT_1' : 'ACCENT_WARNING_BASE'}
+		/>
+	</Tooltip>
+{/key}

--- a/front/src/views/routes/person/[slug]/+page.svelte
+++ b/front/src/views/routes/person/[slug]/+page.svelte
@@ -47,6 +47,7 @@
 	import Card from '../../../components/common/Card/Card.svelte';
 	import Tag from '../../../components/common/Tag/Tag.svelte';
 	import './style.css';
+	import { getCompetitionUrl } from '$lib/utils/competition';
 
 	const personId = $page.params.slug;
 
@@ -329,7 +330,12 @@
 							</ButtonRoot>
 						</TableCell>
 						<TableCell>
-							<ButtonRoot type={'BASIC'} color={'NEUTRAL'}>
+							<ButtonRoot
+								type={'BASIC'}
+								color={'NEUTRAL'}
+								href={getCompetitionUrl(row?.competitionId) || undefined}
+								target={'_blank'}
+							>
 								<Flag stateId={row.competitionState} size={2} />
 								<ButtonText>{row.competitionName}</ButtonText>
 							</ButtonRoot>

--- a/front/src/views/routes/ranking/+page.svelte
+++ b/front/src/views/routes/ranking/+page.svelte
@@ -25,6 +25,7 @@
 	import { rankingStore } from '../../../stores/ranking';
 	import EmptyMessage from '../../components/common/EmptyMessage/EmptyMessage.svelte';
 	import { KEY_PERSISTED_RANKING_FILTERS } from '$lib/constants/ranking';
+	import { formatTimeByEvent } from '$lib/utils/numbers';
 
 	// TODO: Definir valores padrões com base em valores centralizados para cada opção
 	const persistedFilters = localStorage.getItem(KEY_PERSISTED_RANKING_FILTERS);
@@ -127,7 +128,7 @@
 							</ButtonRoot>
 						</TableCell>
 						<TableCell>{row?.wcaId}</TableCell>
-						<TableCell>{row?.best}</TableCell>
+						<TableCell>{formatTimeByEvent(row.best, tableFilters.eventId)}</TableCell>
 						<TableCell>
 							<GridItem justifyContent={'flex-start'} gap={1}>
 								{#if row?.stateId}

--- a/front/src/views/routes/ranking/+page.svelte
+++ b/front/src/views/routes/ranking/+page.svelte
@@ -26,6 +26,7 @@
 	import EmptyMessage from '../../components/common/EmptyMessage/EmptyMessage.svelte';
 	import { KEY_PERSISTED_RANKING_FILTERS } from '$lib/constants/ranking';
 	import { formatTimeByEvent } from '$lib/utils/numbers';
+	import { getCompetitionUrl } from '$lib/utils/competition';
 
 	// TODO: Definir valores padrões com base em valores centralizados para cada opção
 	const persistedFilters = localStorage.getItem(KEY_PERSISTED_RANKING_FILTERS);
@@ -139,9 +140,16 @@
 						</TableCell>
 						<TableCell>
 							{#if row?.competitionState}
-								<Flag stateId={row?.competitionState} size={2} />
+								<ButtonRoot
+									type={'BASIC'}
+									color={'NEUTRAL'}
+									href={getCompetitionUrl(row?.competitionId) || undefined}
+									target={'_blank'}
+								>
+									<Flag stateId={row?.competitionState} size={2} />
+									<ButtonText>{row?.competitionName}</ButtonText>
+								</ButtonRoot>
 							{/if}
-							{row?.competitionName}
 						</TableCell>
 					</TableRow>
 				{/each}


### PR DESCRIPTION
**Improvements:**
- Redirect to competition link when clicking on competition name in tables
- Add option in user menu to view own page
- Add email contact in UI footer

**Fixes:**
- Make the person's account status icon flag reactive
- Format result column in ranking page table according to time conversion rules
- Only show login incentive message when user is on person page

**Evidences:**

<img width="290" alt="Captura de Tela 2025-03-12 às 23 14 53" src="https://github.com/user-attachments/assets/cc76b393-f5dc-4e5d-a81a-29f09b68f0b5" />

<img width="306" alt="Captura de Tela 2025-03-12 às 23 09 41" src="https://github.com/user-attachments/assets/448dbcfc-636b-4e06-9219-96af89f4ce45" />

<img width="1302" alt="Captura de Tela 2025-03-12 às 23 11 00" src="https://github.com/user-attachments/assets/d8f8dd62-ca2a-43cb-846f-a6315108653f" />

<img width="1323" alt="Captura de Tela 2025-03-12 às 23 11 38" src="https://github.com/user-attachments/assets/122f8fd3-41fa-487e-8e3c-37a3f9003e2c" />

<img width="1304" alt="Captura de Tela 2025-03-12 às 23 12 02" src="https://github.com/user-attachments/assets/d6510abd-ecae-44fd-bc08-1822e5f8cb67" />

<img width="1314" alt="Captura de Tela 2025-03-12 às 23 12 28" src="https://github.com/user-attachments/assets/6c526638-e40d-464a-abf0-f474ae0a55ed" />

<img width="1313" alt="Captura de Tela 2025-03-12 às 23 18 20" src="https://github.com/user-attachments/assets/33710b97-afd7-4de7-9c66-6ac7471d2e60" />