### PR TITLE
fix: better refresh operations

### DIFF
--- a/api/pkg/db/models/person.go
+++ b/api/pkg/db/models/person.go
@@ -72,10 +72,9 @@ SELECT
     STR_TO_DATE(CONCAT(comp.year, ',', comp.endMonth, ',', comp.endDay), '%Y,%m,%d') AS ts
 FROM
     datalake.ranking_single dlk
-        LEFT JOIN datalake.competitors ct on dlk.wca_id = ct.wca_id
-        LEFT JOIN datalake.all_persons_with_states al on dlk.wca_id = al.wca_id
-        LEFT JOIN app.registered_users ru on dlk.wca_id = ru.wca_id
-        LEFT JOIN app.estimated_state_by_user
+        LEFT JOIN datalake.competitors ct on (dlk.wca_id = ct.wca_id)
+        LEFT JOIN datalake.all_persons_with_states al on (dlk.wca_id = al.wca_id)
+        LEFT JOIN app.registered_users ru on (dlk.wca_id = ru.wca_id)
         LEFT JOIN dump.Results dmp on (dlk.wca_id = dmp.personId and dlk.event_id = dmp.eventId)
         LEFT JOIN dump.Competitions comp on (dmp.competitionId = comp.id)
         LEFT JOIN datalake.competitions comp2 on (dmp.competitionId = comp2.competition_id)
@@ -105,9 +104,9 @@ SELECT
     STR_TO_DATE(CONCAT(comp.year, ',', comp.endMonth, ',', comp.endDay), '%Y,%m,%d') AS ts
 FROM
     datalake.ranking_average dlk
-        LEFT JOIN datalake.competitors ct on dlk.wca_id = ct.wca_id
-        LEFT JOIN datalake.all_persons_with_states al on dlk.wca_id = al.wca_id
-        LEFT JOIN app.registered_users ru on dlk.wca_id = ru.wca_id
+        LEFT JOIN datalake.competitors ct on (dlk.wca_id = ct.wca_id)
+        LEFT JOIN datalake.all_persons_with_states al on (dlk.wca_id = al.wca_id)
+        LEFT JOIN app.registered_users ru on (dlk.wca_id = ru.wca_id)
         LEFT JOIN dump.Results dmp on (dlk.wca_id = dmp.personId and dlk.event_id = dmp.eventId)
         LEFT JOIN dump.Competitions comp on (dmp.competitionId = comp.id)
         LEFT JOIN datalake.competitions comp2 on (dmp.competitionId = comp2.competition_id)

--- a/api/pkg/db/models/search.go
+++ b/api/pkg/db/models/search.go
@@ -12,11 +12,10 @@ const QuerySearchNameId = `
 SELECT
 	c.wca_id		AS wca_id,
 	c.wca_name		AS wca_name,
-	e.state_id		AS state_id
+	a.state_id		AS state_id
 FROM
 	datalake.competitors c
-		LEFT JOIN datalake.estimated_state_for_user e
-			ON c.wca_id = e.wca_id
+        LEFT JOIN datalake.all_persons_with_states a on c.wca_id = a.wca_id
 WHERE
 	c.wca_id LIKE @search
 	OR c.wca_name LIKE @search

--- a/db/schema/1.2.datalake.sql
+++ b/db/schema/1.2.datalake.sql
@@ -44,6 +44,14 @@ CREATE TABLE IF NOT EXISTS datalake.estimated_state_for_user (
     FOREIGN KEY (wca_id) REFERENCES datalake.competitors(wca_id) ON DELETE CASCADE,
     FOREIGN KEY (state_id) REFERENCES app.states(state_id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS datalake.all_persons_with_states (
+    wca_id              VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+    state_id            CHAR(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+    PRIMARY KEY (wca_id),
+    FOREIGN KEY (state_id) REFERENCES app.states(state_id) ON DELETE CASCADE
+);
+
 -----------------------------------------------------
 
 -- rankings

--- a/db/schema/1.3.dump.sql
+++ b/db/schema/1.3.dump.sql
@@ -1,13 +1,5 @@
 CREATE DATABASE dump;
 
-CREATE TABLE IF NOT EXISTS dump.all_persons_with_states (
-    wca_id              VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-    state_id            CHAR(2) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
-    PRIMARY KEY (wca_id),
-    INDEX (state_id)
-);
-
-
 CREATE TABLE IF NOT EXISTS dump.competitions_by_person_and_country (
     wca_id              VARCHAR(10) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
     country_name        VARCHAR(50) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,

--- a/db/schema/1.4.procedures.sql
+++ b/db/schema/1.4.procedures.sql
@@ -215,6 +215,18 @@ REPLACE INTO dump.results_by_state (
     AND rs.eventId IS NOT NULL
 ;
 
+-- remove old values if the state has changed
+-- as the replace doesnt remove these old values
+DELETE
+FROM dump.results_by_state rs
+WHERE EXISTS (
+    SELECT wca_id, state_id
+    FROM datalake.all_persons_with_states al
+    WHERE
+        rs.wca_id = al.wca_id
+        AND rs.state_id != al.state_id
+);
+
 REPLACE INTO datalake.ranking_single (
     wca_id,
     event_id,

--- a/db/schema/1.4.procedures.sql
+++ b/db/schema/1.4.procedures.sql
@@ -177,7 +177,7 @@ NOT DETERMINISTIC
 MODIFIES SQL DATA
 BEGIN
 
-REPLACE INTO dump.all_persons_with_states (
+REPLACE INTO datalake.all_persons_with_states (
     wca_id,
     state_id
 )
@@ -205,7 +205,7 @@ REPLACE INTO dump.results_by_state (
         rs.best             AS single,
         ra.best             AS average
     FROM
-        dump.all_persons_with_states al
+        datalake.all_persons_with_states al
             LEFT JOIN dump.RanksSingle rs
                 ON al.wca_id = rs.personId
             LEFT JOIN dump.RanksAverage ra
@@ -332,7 +332,7 @@ REPLACE INTO datalake.sum_of_ranks(
 -- )
 --     SELECT
 --     FROM
---         dump.all_persons_with_states al
+--         datalake.all_persons_with_states al
 --             LEFT JOIN (
 --                 SELECT
 --                     sr.wca_id,

--- a/db/utils/reset.sql
+++ b/db/utils/reset.sql
@@ -1,6 +1,6 @@
 DROP TABLE datalake.ranking_average;
 DROP TABLE datalake.ranking_single;
-DROP TABLE dump.all_persons_with_states;
+DROP TABLE datalake.all_persons_with_states;
 DROP TABLE dump.competitions_by_person_and_country;
 DROP TABLE dump.results_by_state;
 DROP TABLE datalake.estimated_state_for_user;


### PR DESCRIPTION
The app.refresh() call was not working properly.
Now it removes old `wca_id/state_id` that aren't being used.

Also, using `dalatake.all_persons_with_states` in all queries, that may solve #11